### PR TITLE
[refactor] use PRG (Post-Redirect-Get) pattern to prevent duplicate form submissions

### DIFF
--- a/Core/Authenticator.php
+++ b/Core/Authenticator.php
@@ -21,12 +21,8 @@ class Authenticator
         session_regenerate_id(true);
     }
     
-    public  function logout() {
-        $_SESSION = [];
-        session_destroy();
-      
-        $params = session_get_cookie_params();
-        setcookie('PHPSESSID','', time()-3600,$params['path'], $params['domain'], $params['secure'], $params['httponly']);
+    public  function logout(){
+      Session::destroy(); 
     }
 
 }

--- a/Core/Session.php
+++ b/Core/Session.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Core; 
+
+class Session
+{
+    public static function has($key)
+    { 
+        return (bool) static::get($key); 
+    }
+
+    public static function put($key, $value)
+    {
+        $_SESSION[$key] = $value;
+    }
+
+    public static function get($key, $default = null)
+    {
+        return  $_SESSION['_flash'][$key] ?? $_SESSION[$key] ?? $default;
+    }
+
+    public static function flash($key, $value)
+    {
+        $_SESSION['_flash'][$key] = $value;
+    }
+
+    public static function unflash()
+    {
+        unset($_SESSION['_flash']);
+    }
+
+    public static function flush ()
+    {
+        $_SESSION = [];
+    }
+
+    public static function destroy()
+    {
+        Session::flush(); 
+        session_destroy();
+        $params = session_get_cookie_params();
+        setcookie('PHPSESSID','', time()-3600,$params['path'], $params['domain'], $params['secure'], $params['httponly']);
+    }
+}

--- a/Http/controllers/session/create.php
+++ b/Http/controllers/session/create.php
@@ -1,6 +1,8 @@
 <?php
 
+use Core\Session;
+
 view('session/create.view.php', [
     'header' => 'Login',
-    'errors' => []
+    'errors' => Session::get('errors')
 ]);

--- a/Http/controllers/session/store.php
+++ b/Http/controllers/session/store.php
@@ -1,6 +1,7 @@
 <?php
 
 use Core\Authenticator;
+use Core\Session;
 use Http\Forms\LoginForm;
 
 $email = $_POST['email'];
@@ -13,10 +14,9 @@ if($form->validate($email,$password)){
     if((new Authenticator)->attempt($email, $password)){
         redirect('/');
     }
-    
     $form->error('email','No matching account found for that email address and password');
 }
 
-return view('session/create.view.php', [
-    'errors' =>  $form->errors()
-]);
+Session::flash('errors', $form->errors());
+
+return redirect('/login');

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use Core\Session;
+
 session_start();
 
 const BASE_PATH = __DIR__ . '/../';
@@ -20,3 +22,5 @@ $uri = parse_url($_SERVER['REQUEST_URI'])['path'];
 $method = $_POST['_method'] ?? $_SERVER['REQUEST_METHOD'];
 
 $router->route($uri, $method);
+
+Session::unflash();


### PR DESCRIPTION
In this episode, we'll discuss the PRG (Post-Redirect-Get) pattern, and how it can be used to prevent duplicate form submissions. Currently, we're returning a view directly from the POST request in the event of failed validation, however, this is far from ideal. Let's review the problem, and then seek a solution.